### PR TITLE
Fix: Use vscodeServerConfig.serverDownloadUrlTemplate to get correct install URL

### DIFF
--- a/src/vscodium/server.ts
+++ b/src/vscodium/server.ts
@@ -86,7 +86,7 @@ export async function installCodeServer(devpodAddr: string, extensionIds: string
         useSocketPath,
         serverApplicationName: vscodeServerConfig.serverApplicationName,
         serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-        serverDownloadUrlTemplate: DEFAULT_DOWNLOAD_URL_TEMPLATE,
+        serverDownloadUrlTemplate: vscodeServerConfig.serverDownloadUrlTemplate || DEFAULT_DOWNLOAD_URL_TEMPLATE
     };
 
     let commandOutput: { stdout: string; stderr: string };


### PR DESCRIPTION
Fixes #26 

Adds `vscodeServerConfig.serverDownloadUrlTemplate` as the preferred download URL template instead of always using the default. This is the same approach used in jeanp413/open-remote-ssh#200 to get the correct download URL on newer VSCodium versions. According to https://github.com/jeanp413/open-remote-ssh/pull/200#issuecomment-2777952507 this change is backwards-compatible.