### PR TITLE
Improvements for building the extension itself in a devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:40
+FROM docker.io/fedora:43
 
 RUN sudo dnf update -y && sudo dnf install -y curl git which zsh pnpm nodejs22
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# We don't COPY any files into the devcontainer, so exclude them all and avoid hashing them
+*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,7 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+
+# When building locally in a container, .pnpm-store can end up in the workspace root (see https://stackoverflow.com/a/78019974)
+# So make sure to exclude it from the extension build.
+.pnpm-store


### PR DESCRIPTION
1. Update the base container image to the latest stable Fedora (43).
1. Deal with the implications of the fact that `.pnpm-store` ends up getting created [inside the workspace directory itself](https://stackoverflow.com/a/78019974) when the workspace is bindmounted into a container:

     1. Add `.pnpm-store` to `.vscodeignore`, in order to prevent `vscepackage` from trying to put the contents of `.pnpm-store` into the packaged extension. Without this ignore, building the VSIX fails with vsce 3.1. (On vsce 2.8 it doesn't fail but results in a bloated VSIX).

    1. Add a `.dockerignore` to exclude all workspace files from the Docker build context. (We can safely do this since we don't COPY any of them.) This saves time on Docker / Podman's hashing step. Also, without this fix, building the container in Devpod fails because the contents of `node_modules` and `.pnpm-store` blow through [Devpod's hard limit of 5000 files in the context](https://github.com/loft-sh/devpod/blob/5a0efcbff6610ab114b421f68a890739a452e66b/pkg/util/hash/hash.go#L21).