### PR TITLE
Respect the user-set SSH config location, and use this to enable a smoother Flatpak experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,12 @@
             "description": "The command to use for running DevPod.",
             "default": "devpod",
             "scope": "machine-overridable"
+          },
+          "remote.devpodcontainers.useDevpodCommandInProxyCommand": {
+            "type": "boolean",
+            "description": "Updates the generated SSH proxy command to use the custom DevPod command. Usually needed when using the VSCodium Flatpak.",
+            "default": false,
+            "scope": "machine-overridable"
           }
         }
       }

--- a/src/devpod/bin.ts
+++ b/src/devpod/bin.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import { spawnSync } from "child_process";
 
+const DEFAULT_DEVPOD_COMMAND = 'devpod';
+
 // Checks if the DevPod bin exists by running `devpod version` as a child process.
 export function devpodBinExists() {
   const devPodCommand = buildDevPodCommand(['version'])
@@ -9,10 +11,19 @@ export function devpodBinExists() {
 }
 
 // Gets the users configured devpod command from their settings.
-function getDevPodCommand() {
+function getDevPodCommandRaw() {
   return vscode.workspace
     .getConfiguration("remote.devpodcontainers")
-    .get<string>("devpodCommand", "devpod");
+    .get<string>("devpodCommand", "");
+}
+
+export function getDevPodCommand() {
+  return getDevPodCommandRaw() || DEFAULT_DEVPOD_COMMAND;
+}
+
+export function useConfiguredDevPodCommand() {
+  // Has the user specified an explicit devpod command (even if it's the same as the default)?
+  return Boolean(getDevPodCommandRaw());
 }
 
 // Construct a devpod command to use with `spawn()` or `spawnSync()`. It will automatically grab the devpod command from the users settings. If the users settings contains spaces (eg. `host-spawn devpod`), it will add everything after the first space into the `args` array.

--- a/src/devpod/commands.ts
+++ b/src/devpod/commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { spawn, spawnSync } from "child_process";
 import { buildDevPodCommand } from "./bin";
+import { buildSshCommand } from "../ssh/ssh";
 
 export async function upDevpod(args: {
   configPath: string;
@@ -72,7 +73,8 @@ export async function listDevpods() {
 
 // a dirty hack until I find a better solution.
 export function findWorkDir(devpodHost: string) {
-  const output = spawnSync("ssh", [devpodHost, "--", "pwd"]);
+  const sshCommand = buildSshCommand([devpodHost, "--", "pwd"]);
+  const output = spawnSync(sshCommand.command, sshCommand.args);
   if (output.stdout) {
     return output.stdout.toString("utf-8").trim();
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import { DevpodTreeView } from "./treeView";
 import { parseCustomizations } from "./spec";
 import { downloadExtension, DOWNLOAD_EXTENSIONS_DIR } from "./marketplace";
+import { copyDevpodToCustomSshConfig } from "./ssh/configManagement";
 
 // TODO: not fail when open vsx in not available
 
@@ -110,6 +111,8 @@ async function openContainer(recreate: boolean = false) {
     return;
   }
   const devpodHost = `${devpod.id}.devpod`;
+
+  copyDevpodToCustomSshConfig(devpodHost);
 
   const customizations = parseCustomizations(config.fsPath);
   const exts = customizations.extensions;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { DevpodTreeView } from "./treeView";
 import { parseCustomizations } from "./spec";
 import { downloadExtension, DOWNLOAD_EXTENSIONS_DIR } from "./marketplace";
-import { copyDevpodToCustomSshConfig } from "./ssh/configManagement";
+import { copyDevpodToCustomSshConfig, validateDevpodAndSshSettings } from "./ssh/configManagement";
 
 // TODO: not fail when open vsx in not available
 
@@ -112,6 +112,11 @@ async function openContainer(recreate: boolean = false) {
   }
   const devpodHost = `${devpod.id}.devpod`;
 
+  const errors = validateDevpodAndSshSettings();
+  if (errors.length) {
+    vscode.window.showErrorMessage(errors.join("\n"));
+    return;
+  }
   copyDevpodToCustomSshConfig(devpodHost);
 
   const customizations = parseCustomizations(config.fsPath);

--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { spawnSync } from "child_process";
+import { buildSshCommand } from "./ssh/ssh";
 
 export const DOWNLOAD_EXTENSIONS_DIR = "$HOME/.devpodcontainers/extensions";
 
@@ -66,5 +67,6 @@ export async function downloadExtension(args: {
 		${url}\n`;
 
   // TODO: write output to output channel
-  spawnSync("ssh", [args.devpodHost, "--", "bash", "-c", `'${script}'`]);
+  const sshCommand = buildSshCommand([args.devpodHost, "--", "bash", "-c", `'${script}'`]);
+  spawnSync(sshCommand.command, sshCommand.args);
 }

--- a/src/ssh/configManagement.ts
+++ b/src/ssh/configManagement.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { customSshConfigPath, defaultSshConfigPath, useNonDefaultSshConfig } from "./ssh";
+
+export function copyDevpodToCustomSshConfig(devpodAddr: string) {
+  // Copies the stanza belonging to the devpod <devpodAddr> from the default SSH config to
+  // the user-configured one (in the remote.SSH.configFile preference)
+  if (!useNonDefaultSshConfig()) {
+    return;  // Nowhere to copy to
+  }
+  const sourceConfigLines = readFileLines(defaultSshConfigPath());
+  let targetConfigLines = readFileLines(customSshConfigPath());
+  const sourceHostStanza = getHostStanza(sourceConfigLines, devpodAddr);
+  updateOrAppendHostStanza(targetConfigLines, devpodAddr, sourceHostStanza);
+  writeFileLines(customSshConfigPath(), targetConfigLines);
+}
+
+function readFileLines(filePath: string) {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+  return readFileSync(filePath, {"encoding": "utf8"}).split("\n");
+}
+
+function getHostStanza(configLines: string[], hostName: string) {
+  // Search in <configLines> and return the lines of the stanza for host <hostName>
+  const pos = findHostStanzaPosition(configLines, hostName);
+  if (pos[0] == -1) {
+    return [];
+  }
+  return configLines.slice(...pos);
+}
+
+function updateOrAppendHostStanza(configLines: string[], hostName: string, hostStanza: string[]) {
+  // Add the lines <hostStanza> to <configLines>, replacing any existing stanze for host <hostName>
+  const pos = findHostStanzaPosition(configLines, hostName);
+  if (pos[0] == -1) {  // No existing stanza, so just append it
+    configLines.push(...hostStanza);
+  } else {  // Splice in the new stanza, replacing the existing one
+    configLines.splice(pos[0], pos[1] - pos[0], ...hostStanza);
+  }
+}
+
+function writeFileLines(filePath: string, lines: string[]) {
+  writeFileSync(filePath, lines.join("\n"), {"encoding": "utf8"});
+}
+
+const HOST_REGEXP = new RegExp("^\\s*Host\\s*[\\s=]\\s*(\\S+)\\s*$", "i");
+const DEVPOD_COMMENT_REGEXP = new RegExp("^#\\s*DevPod", "i");
+
+function findHostStanzaPosition(configLines: string[], hostName: string) {
+  // Looks in the SSH config lines <configLines> for a stanza for host <hostName>
+  // Returns its position [stanzaStartLine, stanzaEndLine] using array slice notation, i.e.
+  // stanzaEndLine is the first line of the next stanza.
+  // Returns [-1, -1] if no stanza is found.
+  let stanzaStartLine = -1;
+  let stanzaEndLine = -1;
+  let previousLineWasComment = false;
+  for (let i=0; i < configLines.length; i++) {
+    let match = configLines[i].match(HOST_REGEXP);
+    if (match) { // this line is a host declaration
+      if (match[1] == hostName) {
+        // Found the start of our target stanza
+        // If the previous line was a comment, assume it's part of this host stanza
+        stanzaStartLine = previousLineWasComment ? i-1 : i;
+      } else {
+        // It's the start of a different host's stanza
+        if (stanzaStartLine != -1) {
+          // Found the end of our target stanza
+          stanzaEndLine = previousLineWasComment ? i-1 : i;
+          break;
+        }
+      }
+    }
+    previousLineWasComment = DEVPOD_COMMENT_REGEXP.test(configLines[i]);
+  }
+  if (stanzaStartLine != -1 && stanzaEndLine == -1) {
+    // Target host was the last one in the file
+    stanzaEndLine = configLines.length;
+  }
+  return [stanzaStartLine, stanzaEndLine];
+}

--- a/src/ssh/configManagement.ts
+++ b/src/ssh/configManagement.ts
@@ -1,5 +1,26 @@
+import * as vscode from "vscode";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { customSshConfigPath, defaultSshConfigPath, useNonDefaultSshConfig } from "./ssh";
+import { getDevPodCommand, useConfiguredDevPodCommand } from "../devpod/bin";
+
+export function validateDevpodAndSshSettings() {
+  let errors = [];
+  if (shouldOverrideProxyCommand()) {
+    if (!useNonDefaultSshConfig()) {
+      errors.push("'Use Devpod Command In Proxy Command' is set, but 'Remote.SSH Config File' is not set.");
+    }
+    if (!useConfiguredDevPodCommand()) {
+      errors.push("'Use Devpod Command In Proxy Command' is set, but 'Devpod Command' is not set.");
+    }
+  }
+  return errors;
+}
+
+function shouldOverrideProxyCommand() {
+  return vscode.workspace
+    .getConfiguration("remote.devpodcontainers")
+    .get<Boolean>("useDevpodCommandInProxyCommand", false);
+}
 
 export function copyDevpodToCustomSshConfig(devpodAddr: string) {
   // Copies the stanza belonging to the devpod <devpodAddr> from the default SSH config to
@@ -10,6 +31,9 @@ export function copyDevpodToCustomSshConfig(devpodAddr: string) {
   const sourceConfigLines = readFileLines(defaultSshConfigPath());
   let targetConfigLines = readFileLines(customSshConfigPath());
   const sourceHostStanza = getHostStanza(sourceConfigLines, devpodAddr);
+  if (shouldOverrideProxyCommand()) {
+    overrideProxyCommandInLines(sourceHostStanza);
+  }
   updateOrAppendHostStanza(targetConfigLines, devpodAddr, sourceHostStanza);
   writeFileLines(customSshConfigPath(), targetConfigLines);
 }
@@ -78,4 +102,21 @@ function findHostStanzaPosition(configLines: string[], hostName: string) {
     stanzaEndLine = configLines.length;
   }
   return [stanzaStartLine, stanzaEndLine];
+}
+
+// Pattern to identify the proxy command spec. It will look like:
+// "ProxyCommand <devpod binary> ssh <more options>", where the devpod command might be multi-word.
+// Regex has 3 capturing groups: (1) everything before the devpod binary, (2) the devpod binary,
+// (3) everything after.
+const PROXY_COMMAND_REGEXP = new RegExp("^(\\s*ProxyCommand\\s*[\\s=]\\s*)(.*)(\\sssh\\s.*)", "i");
+
+function overrideProxyCommandInLines(configLines: string[]) {
+  // Looks in the SSH config lines <configLines> for a ProxyCommand entry invoking '<devpod binary> ssh',
+  // and modifies that line, replacing the devpod binary with the devpod command as configured by the user.
+  for (let i=0; i < configLines.length; i++) {
+    if (PROXY_COMMAND_REGEXP.test(configLines[i])) {
+      configLines[i] = configLines[i].replace(PROXY_COMMAND_REGEXP, `$1${getDevPodCommand()}$3`);
+      break;
+    }
+  }
 }

--- a/src/ssh/ssh.ts
+++ b/src/ssh/ssh.ts
@@ -1,0 +1,33 @@
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+
+export function customSshConfigPath() {
+  let p = vscode.workspace
+    .getConfiguration("remote.SSH")
+    .get<string>("configFile", "");
+  if (p.startsWith("~")) {
+    p = path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}
+
+export function defaultSshConfigPath() {
+  return path.resolve(os.homedir(), ".ssh/config");
+}
+
+export function useNonDefaultSshConfig() {
+  let p = customSshConfigPath();
+  return Boolean(p && (p != defaultSshConfigPath()));
+}
+
+export function buildSshCommand(args: string[] = []) {
+  let argArray = [...args];
+  if (useNonDefaultSshConfig()) {
+    argArray.unshift("-F", customSshConfigPath());
+  }
+  return {
+    command: "ssh",
+    args: argArray
+  }
+}

--- a/src/vscodium/server.ts
+++ b/src/vscodium/server.ts
@@ -7,6 +7,7 @@
 
 import * as crypto from 'crypto';
 import { spawnSync } from 'child_process';
+import { buildSshCommand } from '../ssh/ssh';
 
 export interface ServerInstallOptions {
     id: string;
@@ -51,7 +52,8 @@ export async function installCodeServer(devpodAddr: string, extensionIds: string
 
     // detect plaform and shell for windows
     if (!platform || platform === 'windows') {
-        const result = spawnSync(`ssh ${devpodAddr} -- uname -s`);
+        const sshCommand = buildSshCommand([devpodAddr, "--", "uname", "-s"]);
+        const result = spawnSync(sshCommand.command, sshCommand.args);
 
         if (result.stdout) {
             if (result.stdout.includes('windows32')) {
@@ -141,7 +143,8 @@ export async function installCodeServer(devpodAddr: string, extensionIds: string
         // Fish shell does not support heredoc so let's workaround it using -c option,
         // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
         // const out = spawnSync(`ssh ${devpodAddr} -- bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
-        const out = spawnSync('ssh', [devpodAddr, '--', 'bash', '-c', `'${installServerScript.replace(/'/g, `'\\''`)}'`]);
+        const sshCommand = buildSshCommand([devpodAddr, '--', 'bash', '-c', `'${installServerScript.replace(/'/g, `'\\''`)}'`]);
+        const out = spawnSync(sshCommand.command, sshCommand.args);
         commandOutput = {
             stdout: out.stdout.toString(),
             stderr: out.stderr.toString(),


### PR DESCRIPTION
The Open Remote SSH extension which we depend on has a config option allowing the user to [select their own SSH configuration file location](https://github.com/jeanp413/open-remote-ssh#ssh-configuration-file).

Currently, if the user sets that location, then opening the devpod container from inside VSCodium breaks. (Because `devpod up` writes the SSH config for the devpod to `~/.ssh/config`, where the Open Remote SSH extension won't find it.)

This PR adds support for the custom config location, by copying the config lines written by devpod up into the file at the custom location. So the devpod container is accessible both from the Open Remote SSH extension, and also from `ssh mypodname.devpod` in a normal shell (because the original config lines are still in `~/.ssh/config`).

---

Also, we can use this mechanism to enable a smoother experience with Flatpak VSCodium. Currently, since https://github.com/3timeslazy/vscodium-devpodcontainers/commit/98796d026df640db5216bf60b46725f95812a4fa, the user can set a custom devpod command (e.g. `flatpak-spawn --host devpod` or `host-spawn devpod`) to allow devpod on the host to be invoked from the extension.

That enables the extension to successfully execute `devpod up` when running in Flatpak VSCodium - but after that, the extension fails to SSH into the container, because the SSH config written by `devpod up` contains a line like…

```
ProxyCommand /usr/bin/devpod ssh mypodname.devpod --someoptions
```

…and that `/usr/bin/devpod` command won't work from Flatpak VSCodium without workarounds like the wrapper script suggested in #33 .

So this PR adds a config option “Use Devpod Command in Proxy Command”. If the user selects that option, then the ProxyCommand in the SSH config at the custom location (but not at `~/.ssh/config`) will be modified to use the user's custom devpod command, like:

```
ProxyCommand host-spawn devpod ssh mypodname.devpod --someoptions
```

This way, the devpod is fully accessible both from Flatpak VSCodium and from a normal host-side shell.